### PR TITLE
Do LUKS encryption/decryption inline outside of IRQ

### DIFF
--- a/include/uapi/linux/sysctl.h
+++ b/include/uapi/linux/sysctl.h
@@ -832,6 +832,7 @@ enum {
 	DEV_MAC_HID=5,
 	DEV_SCSI=6,
 	DEV_IPMI=7,
+	DEV_DM_CRYPT=8,
 };
 
 /* /proc/sys/dev/cdrom */
@@ -853,6 +854,11 @@ enum {
 enum {
 	DEV_RAID_SPEED_LIMIT_MIN=1,
 	DEV_RAID_SPEED_LIMIT_MAX=2
+};
+
+/* /proc/sys/dev/dm_crypt */
+enum {
+	DM_CRYPT_MAX_INLINE_SIZE=1
 };
 
 /* /proc/sys/dev/parport/default */

--- a/kernel/sysctl_binary.c
+++ b/kernel/sysctl_binary.c
@@ -827,6 +827,10 @@ static const struct bin_table bin_raid_table[] = {
 	{}
 };
 
+static const struct bin_table bin_dm_crypt_table[] = {
+	{ CTL_INT,	DM_CRYPT_MAX_INLINE_SIZE,	"max_inline_size" },
+};
+
 static const struct bin_table bin_scsi_table[] = {
 	{ CTL_INT, DEV_SCSI_LOGGING_LEVEL, "logging_level" },
 	{}
@@ -837,6 +841,7 @@ static const struct bin_table bin_dev_table[] = {
 	/* DEV_HWMON unused */
 	/* DEV_PARPORT	"parport" no longer used */
 	{ CTL_DIR,	DEV_RAID,	"raid",		bin_raid_table },
+	{ CTL_DIR,	DEV_DM_CRYPT,	"dm_crypt",	bin_dm_crypt_table },
 	{ CTL_DIR,	DEV_MAC_HID,	"mac_hid",	bin_mac_hid_files },
 	{ CTL_DIR,	DEV_SCSI,	"scsi",		bin_scsi_table },
 	{ CTL_DIR,	DEV_IPMI,	"ipmi",		bin_ipmi_table },


### PR DESCRIPTION
The idea was that scheduling LUKS crypto onto workqueue instead of performing encryption or decryption immediately may cause extra latency we can try to avoid.

This patch works with SCSI devices, but falls short with NVMe, which do BIO completion in interrupt context. For ease of testing it provides `dev.dm_crypt.max_inline_size` sysctl to set max size of BIO in bytes to perform crypto operations without queuing. We're also skipping any crypto in interrupts, because of this:

```
[  546.126534] WARNING: CPU: 13 PID: 0 at crypto/skcipher.c:429 skcipher_walk_first+0x45/0x100
[  546.135166] Modules linked in: ipt_MASQUERADE nf_conntrack_netlink xfrm_user xfrm_algo xt_addrtype br_netfilter bridge overlay md_mod dm_crypt algif_skcipher af_alg dm_mod dax ip6table_nat nf_nat_ipv6 ip6table_mangle ip6table_security ip6table_raw ip6table_filter ip6_tables iptable_nat nf_nat_ipv4 nf_nat iptable_mangle xt_CT iptable_raw xt_tcpudp xt_comment xt_conntrack xt_multiport xt_set iptable_filter bpfilter ip_set_hash_netport ip_set_hash_net ip_set_hash_ip ip_set nfnetlink nf_conntrack nf_defrag_ipv6 nf_defrag_ipv4 8021q garp mrp stp llc bonding ses enclosure sb_edac x86_pkg_temp_thermal kvm_intel ipmi_ssif kvm irqbypass crc32_pclmul crc32c_intel pcbc mpt3sas igb aesni_intel mlx5_core aes_x86_64 i2c_algo_bit raid_class crypto_simd mlxfw ipmi_si cryptd ipmi_devintf devlink scsi_transport_sas
[  546.207941]  dca glue_helper ipmi_msghandler hid_generic efivarfs ip_tables x_tables
[  546.215937] CPU: 13 PID: 0 Comm: swapper/13 Not tainted 4.19.2-cloudflare-2018.11.1-5-gb4afdf6 #1
[  546.225069] Hardware name: Quanta Cloud Technology Inc. QuantaGrid D51PH-1ULH/S2PH-MB, BIOS S2P_3B08.01 03/20/2017
[  546.235734] RIP: 0010:skcipher_walk_first+0x45/0x100
[  546.240868] Code: 90 00 00 00 48 89 fb 48 c7 47 68 00 00 00 00 85 6f 78 75 24 48 c7 43 60 00 00 00 00 48 89 df 5b 5d 41 5c 41 5d e9 cb fa ff ff <0f> 0b b8 dd ff ff ff 5b 5d 41 5c 41 5d c3 44 8b af 8c 00 00 00 89
[  546.260207] RSP: 0018:ffff88fb3f6c3ce0 EFLAGS: 00010006
[  546.265599] RAX: 0000000080010000 RBX: ffff88fb3f6c3d40 RCX: ffffffffc0547da0
[  546.282623] RDX: ffff88faf9fb0028 RSI: ffff88fafd9cc970 RDI: ffff88fb3f6c3d40
[  546.299706] RBP: 0000000000000000 R08: ffff88faf9fb0260 R09: ffff88fafd9ccae8
[  546.316739] R10: ffff88fb2d130000 R11: 0000000000000000 R12: ffff88faf9fb0070
[  546.333626] R13: ffff88fafd851c00 R14: ffffffffc05460a0 R15: 0000000000000000
[  546.350381] FS:  0000000000000000(0000) GS:ffff88fb3f6c0000(0000) knlGS:0000000000000000
[  546.368246] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[  546.383796] CR2: 00007f4e4b474000 CR3: 0000000aca20a006 CR4: 00000000003606e0
[  546.400884] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
[  546.417986] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
[  546.435046] Call Trace:
[  546.447224]  <IRQ>
[  546.458804]  skcipher_walk_virt+0x18/0x40
[  546.472488]  ? xts_encrypt+0x40/0x40 [aesni_intel]
[  546.486926]  glue_xts_req_128bit+0x49/0x190 [glue_helper]
[  546.502043]  ? crypt_convert+0xb1b/0xf60 [dm_crypt]
[  546.516705]  ? ktime_get+0x37/0xa0
[  546.529808]  ? blkcg_iolatency_done_bio+0x2b/0x3b0
[  546.544418]  ? kcryptd_queue_crypt+0xc4/0x390 [dm_crypt]
[  546.559526]  ? blk_update_request+0xc0/0x260
[  546.573474]  ? blk_mq_end_request+0x1a/0xd0
[  546.587258]  ? flush_smp_call_function_queue+0x6c/0xe0
[  546.601882]  ? smp_call_function_single_interrupt+0x3a/0xd0
[  546.616895]  ? call_function_single_interrupt+0xf/0x20
[  546.631453]  </IRQ>
[  546.642937]  ? cpuidle_enter_state+0xb0/0x300
[  546.656673]  ? do_idle+0x1ab/0x1f0
[  546.669203]  ? cpu_startup_entry+0x6f/0x80
[  546.682225]  ? start_secondary+0x183/0x1b0
[  546.695225]  ? secondary_startup_64+0xa4/0xb0
[  546.708474] ---[ end trace 027f42f55539ed16 ]---
```

All tests are on machines with Intel Xeon E5-2630 v3 @ 2.40GHz running in performance mode (which is questionable). CPUs are shut down with `isolcpus=1-31`, so only one HT is active in single CPU mode. We also shut background services like metric collection in single CPU mode to avoid unwanted interference.

```
$ uname -r
4.19.2-cloudflare-2018.11.1-6-gd53a301

$ sudo lscpu
Architecture:          x86_64
CPU op-mode(s):        32-bit, 64-bit
Byte Order:            Little Endian
CPU(s):                32
On-line CPU(s) list:   0-31
Thread(s) per core:    2
Core(s) per socket:    8
Socket(s):             2
NUMA node(s):          2
Vendor ID:             GenuineIntel
CPU family:            6
Model:                 63
Model name:            Intel(R) Xeon(R) CPU E5-2630 v3 @ 2.40GHz
Stepping:              2
CPU MHz:               1248.959
CPU max MHz:           3200.0000
CPU min MHz:           1200.0000
BogoMIPS:              4788.71
Virtualization:        VT-x
L1d cache:             32K
L1i cache:             32K
L2 cache:              256K
L3 cache:              20480K
NUMA node0 CPU(s):     0-7,16-23
NUMA node1 CPU(s):     8-15,24-31
Flags:                 fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm cpuid_fault epb invpcid_single pti intel_ppin ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid cqm xsaveopt cqm_llc cqm_occup_llc dtherm ida arat pln pts flush_l1d

$ sudo cpufreq-info -c 0
cpufrequtils 008: cpufreq-info (C) Dominik Brodowski 2004-2009
Report errors and bugs to cpufreq@vger.kernel.org, please.
analyzing CPU 0:
  driver: intel_pstate
  CPUs which run at the same hardware frequency: 0
  CPUs which need to have their frequency coordinated by software: 0
  maximum transition latency: 4294.55 ms.
  hardware limits: 1.20 GHz - 3.20 GHz
  available cpufreq governors: performance, powersave
  current policy: frequency should be within 1.20 GHz and 1.20 GHz.
                  The governor "performance" may decide which speed to use
                  within this range.
  current CPU frequency is 1.47 GHz.
```

Script used to measure IO throughput:

```sh
#!/bin/bash -e

SIZE=$((1024 * 1024 * 1024))

for power in $(seq 10 30); do
  BS=$((2 ** $power))
  COUNT=$(($SIZE / $BS))
  TIME_DIRECT=$(sudo dd if=/dev/sdm of=/dev/null bs=$BS count=$COUNT iflag=direct 2>&1 | tail -n1 | awk '{ print $(NF-1) }')
  TIME_LUKS_SYNC=$(sudo sysctl -q -w dev.dm_crypt.max_inline_size=$BS && sudo dd if=/dev/mapper/luks-sdm of=/dev/null bs=$BS count=$COUNT iflag=direct 2>&1 | tail -n1 | awk '{ print $(NF-1) }')
  TIME_LUKS_ASYNC=$(sudo sysctl -q -w dev.dm_crypt.max_inline_size=0 && sudo dd if=/dev/mapper/luks-sdm of=/dev/null bs=$BS count=$COUNT iflag=direct 2>&1 | tail -n1 | awk '{ print $(NF-1) }')
  echo -e "${BS}\t${TIME_DIRECT}\t${TIME_LUKS_SYNC}\t${TIME_LUKS_ASYNC}"
done
```

Here `/dev/sdm` is the block device and `/dev/mapper/luks-sdm` is the corresponding LUKS device. Output format:
```
<read size>    <plain block device speed>    <async luks speed>    <sync luks speed>
```

It's not the most scientific test, we're just trying to see if the change helps.

Benchmark from `cryptsetup` gives the following numbers for AES-XTS:

```
$ sudo cryptsetup benchmark -c aes-xts
# Tests are approximate using memory only (no storage IO).
#  Algorithm | Key |  Encryption |  Decryption
     aes-xts   256b  1632.7 MiB/s  1654.1 MiB/s
```

## Terrible SSD (INTEL SSDSC2BW240A4)

### Single CPU

```
1024	19.0	18.0	17.8
2048	32.6	31.4	30.9
4096	53.1	48.4	48.8
8192	80.5	73.1	72.6
16384	114	97.4	96.3
32768	142	111	116
65536	167	132	130
131072	209	154	157
262144	264	192	191
524288	298	224	229
1048576	326	246	250
2097152	336	261	251
4194304	342	297	275
8388608	328	322	323
16777216	350	339	330
33554432	351	345	347
67108864	350	348	352
134217728	353	354	354
268435456	345	351	353
536870912	355	356	345
1073741824	356	354	357
```

![image](https://user-images.githubusercontent.com/89186/48873881-333fb500-eda5-11e8-822f-53958e70fdac.png)

### Multiple CPUs

```
1024	18.8	18.0	16.9
2048	31.6	29.3	28.5
4096	51.3	47.0	46.6
8192	77.5	70.7	67.4
16384	111	95.3	90.4
32768	133	106	103
65536	160	122	117
131072	199	148	141
262144	253	184	164
524288	296	224	218
1048576	325	246	241
2097152	326	257	253
4194304	342	296	295
8388608	346	321	310
16777216	342	332	333
33554432	351	334	344
67108864	353	346	338
134217728	344	352	342
268435456	354	351	353
536870912	355	343	334
1073741824	340	332	339
```

![image](https://user-images.githubusercontent.com/89186/48874791-eb6f5c80-eda9-11e8-9988-59422ed47263.png)

## Conclusion

Up to 16KiB synchronous decryption wins in both cases, after that it's not as clear, as decryption overhead is much higher than scheduling decryption asynchronously.

With multiple CPUs margins are larger. Kernel schedules unbound `kcryptd` kworker on a different CPU, which is likely to run at a lower frequency. That other CPU does not get enough load from AES decryption at low bandwidth, which means that frequency remains low, which in turns slows down decryption and overall throughput.

This theory is confirmed by smaller margin when `kcryptd` is forced on the same CPU.

## Less terrible SSD (INTEL SSDSC2BB120G4)

### Single CPU

```
1024	36.7	33.5	32.4
2048	69.4	62.5	59.1
4096	122	108	104
8192	193	160	153
16384	269	217	211
32768	340	256	258
65536	355	275	274
131072	301	235	235
262144	292	267	255
524288	329	268	267
1048576	358	269	269
2097152	394	292	292
4194304	419	354	356
8388608	431	394	398
16777216	442	422	423
33554432	449	436	435
67108864	449	444	446
134217728	450	447	447
268435456	451	450	449
536870912	448	449	451
1073741824	451	448	448
```

![image](https://user-images.githubusercontent.com/89186/48874690-59ffea80-eda9-11e8-9109-4e22a9d4cc7b.png)

### Multiple CPUs

```
1024	34.5	30.2	28.5
2048	64.1	56.0	53.1
4096	114	96.5	91.3
8192	182	147	141
16384	260	196	196
32768	334	243	235
65536	357	258	260
131072	290	252	255
262144	291	261	264
524288	332	245	240
1048576	362	257	255
2097152	393	279	277
4194304	418	340	341
8388608	435	390	388
16777216	439	415	418
33554432	447	432	430
67108864	447	443	443
134217728	447	444	446
268435456	451	449	447
536870912	448	448	450
1073741824	451	447	449
```

![image](https://user-images.githubusercontent.com/89186/48875550-705c7500-edae-11e8-96fc-a13d0c07f430.png)

### Conclusion

Here we see a picture that's similar to a terrible SSD, with the only difference that the optimal IO size for immediate decryption drops from 16KiB to 8KiB due to faster SSD giving more data to decrypt.

## Loop device backed by a file in page cache

```
$ sudo dd if=/dev/zero of=/state/loop-10g bs=1M count=10K
$ sudo cryptsetup -q luksFormat /state/loop-10g /etc/luks/luks.key
$ sudo losetup /dev/loop0 /state/loop-10g
$ sudo cryptsetup open --allow-discards --type luks --key-file /etc/luks/luks.key /dev/loop0 luks-loop
```

We force the backing file into page cache by reading it:

```
$ time cat /state/loop-10g > /dev/null

real	0m1.445s
user	0m0.015s
sys	0m1.429s
$ time cat /state/loop-10g > /dev/null

real	0m1.395s
user	0m0.020s
sys	0m1.375s
```

Speed of RAM goes into GB/s, so we change our script a little:

```
#!/bin/bash -e

SIZE=$((1024 * 1024 * 1024))

for power in $(seq 10 30); do
  BS=$((2 ** $power))
  COUNT=$(($SIZE / $BS))
  TIME_DIRECT=$(sudo dd if=/dev/ram0 of=/dev/null bs=$BS count=$COUNT iflag=direct 2>&1 | tail -n1 | awk '{ print $(NF-1) }')
  TIME_LUKS_SYNC=$(sudo sysctl -q -w dev.dm_crypt.max_inline_size=$BS && sudo dd if=/dev/mapper/luks-ram0 of=/dev/null bs=$BS count=$COUNT iflag=direct 2>&1 | tail -n1 | awk '{ print $(NF-1) }')
  TIME_LUKS_ASYNC=$(sudo sysctl -q -w dev.dm_crypt.max_inline_size=0 && sudo dd if=/dev/mapper/luks-ram0 of=/dev/null bs=$BS count=$COUNT iflag=direct 2>&1 | tail -n1 | awk '{ print $(NF-1) }')
  echo -e "${BS} ${TIME_DIRECT} ${TIME_LUKS_SYNC} ${TIME_LUKS_ASYNC}" | awk '{ printf("%s\t%.1f\t%.1f\t%.1f\n", $1, $2 > 50 ? $2 : $2 * 1000, $3 > 50 ? $3 : $3 * 1000, $4 > 50 ? $4 : $4 * 1000) }'
done
```

### Single CPU

```
1024	126.0	112.0	105.0
2048	294.0	202.0	188.0
4096	542.0	336.0	282.0
8192	709.0	412.0	449.0
16384	1600.0	654.0	634.0
32768	2400.0	775.0	756.0
65536	3200.0	850.0	841.0
131072	4000.0	908.0	907.0
262144	4600.0	929.0	934.0
524288	5100.0	961.0	962.0
1048576	5000.0	971.0	983.0
2097152	4900.0	975.0	983.0
4194304	5200.0	982.0	991.0
8388608	5000.0	968.0	958.0
16777216	3400.0	882.0	905.0
33554432	3400.0	890.0	901.0
67108864	3300.0	870.0	882.0
134217728	3100.0	884.0	893.0
268435456	3100.0	860.0	876.0
536870912	2100.0	844.0	840.0
1073741824	2200.0	776.0	794.0
```

![image](https://user-images.githubusercontent.com/89186/48875471-21aedb00-edae-11e8-8d46-072a2ed671d2.png)

### Multiple CPUs

```
1024	123.0	97.9	66.1
2048	224.0	178.0	150.0
4096	486.0	306.0	252.0
8192	896.0	461.0	402.0
16384	1500.0	625.0	563.0
32768	2400.0	766.0	691.0
65536	3400.0	862.0	832.0
131072	4100.0	909.0	911.0
262144	4700.0	885.0	879.0
524288	5100.0	928.0	938.0
1048576	5200.0	958.0	972.0
2097152	5100.0	982.0	991.0
4194304	5600.0	999.0	1300.0
8388608	4300.0	1800.0	1700.0
16777216	2900.0	2300.0	2200.0
33554432	2800.0	2700.0	2600.0
67108864	2800.0	2900.0	2900.0
134217728	2800.0	3000.0	3000.0
268435456	3700.0	917.0	3200.0
536870912	2700.0	3100.0	3300.0
1073741824	3400.0	3300.0	3200.0
```

![image](https://user-images.githubusercontent.com/89186/48875482-2e333380-edae-11e8-83d1-879151192888.png)

### Conclusion

This is similar to SSDs, plus we have some overhead from XFS reading file from page cache.

Synchronous decryption has some gains up to 64KiB read blocks.

## Ram block device

```
$ sudo modprobe brd rd_size=$((1024 * 1024 * 10))
$ sudo cryptsetup -q luksFormat /dev/ram0 /etc/luks/luks.key
$ sudo cryptsetup open --allow-discards --type luks --key-file /etc/luks/luks.key /dev/ram0 luks-ram0
```

Test script is similar to a loopback backed by a cached file:

```sh
#!/bin/bash -e

SIZE=$((1024 * 1024 * 1024))

for power in $(seq 10 30); do
  BS=$((2 ** $power))
  COUNT=$(($SIZE / $BS))
  TIME_DIRECT=$(sudo dd if=/dev/ram0 of=/dev/null bs=$BS count=$COUNT iflag=direct 2>&1 | tail -n1 | awk '{ print $(NF-1) }')
  TIME_LUKS_SYNC=$(sudo sysctl -q -w dev.dm_crypt.max_inline_size=$BS && sudo dd if=/dev/mapper/luks-ram0 of=/dev/null bs=$BS count=$COUNT iflag=direct 2>&1 | tail -n1 | awk '{ print $(NF-1) }')
  TIME_LUKS_ASYNC=$(sudo sysctl -q -w dev.dm_crypt.max_inline_size=0 && sudo dd if=/dev/mapper/luks-ram0 of=/dev/null bs=$BS count=$COUNT iflag=direct 2>&1 | tail -n1 | awk '{ print $(NF-1) }')
  echo -e "${BS} ${TIME_DIRECT} ${TIME_LUKS_SYNC} ${TIME_LUKS_ASYNC}" | awk '{ printf("%s\t%.1f\t%.1f\t%.1f\n", $1, $2 > 50 ? $2 : $2 * 1000, $3 > 50 ? $3 : $3 * 1000, $4 > 50 ? $4 : $4 * 1000) }'
done
```

### Single CPU

```
1024	834.0	363.0	173.0
2048	1600.0	539.0	341.0
4096	3200.0	731.0	534.0
8192	6000.0	870.0	724.0
16384	10100.0	955.0	896.0
32768	12000.0	995.0	1000.0
65536	15300.0	1000.0	1100.0
131072	17600.0	1000.0	1100.0
262144	18000.0	1000.0	1100.0
524288	18200.0	1000.0	1100.0
1048576	18400.0	1000.0	1100.0
2097152	18500.0	1000.0	1200.0
4194304	18200.0	1000.0	1100.0
8388608	17900.0	1000.0	1100.0
16777216	10500.0	994.0	1100.0
33554432	5400.0	916.0	1000.0
67108864	5000.0	909.0	986.0
134217728	4900.0	898.0	984.0
268435456	4600.0	892.0	966.0
536870912	4000.0	869.0	939.0
1073741824	3300.0	824.0	891.0
```

![image](https://user-images.githubusercontent.com/89186/48875501-46a34e00-edae-11e8-940a-68716f25f379.png)

### Multiple CPUs

```
1024	838.0	360.0	131.0
2048	1600.0	544.0	244.0
4096	3200.0	714.0	392.0
8192	5900.0	852.0	558.0
16384	9900.0	937.0	742.0
32768	11900.0	978.0	863.0
65536	14700.0	965.0	949.0
131072	16600.0	987.0	1100.0
262144	16700.0	1000.0	1000.0
524288	17000.0	1000.0	1100.0
1048576	17100.0	1000.0	1100.0
2097152	17100.0	977.0	1100.0
4194304	16800.0	1000.0	1900.0
8388608	16600.0	1000.0	3400.0
16777216	11600.0	962.0	4500.0
33554432	5200.0	834.0	3900.0
67108864	4900.0	888.0	4100.0
134217728	4700.0	891.0	4300.0
268435456	4400.0	853.0	3800.0
536870912	3900.0	856.0	3700.0
1073741824	3100.0	822.0	3000.0
```

![image](https://user-images.githubusercontent.com/89186/48875099-b82dcd00-edab-11e8-9ba5-ea734a391502.png)

### Conclusion

???

## Overall conclusion

It seems like there's some win up to 5% from doing small IO decryption without putting it on a workqueue, but it diminishes with size and doesn't work with NVMe. It may make more sense on a fast SCSI devices.